### PR TITLE
Working version of restructured extensions overlay, with logo redirection change

### DIFF
--- a/public/OpenAIRE_OCA_package.json
+++ b/public/OpenAIRE_OCA_package.json
@@ -1415,16 +1415,162 @@
     ]
   },
   "extensions": {
-    "adc" : {
-      "EIC9__U1uCn0UaREPwlM7h2gYJ4J0EW042qzpjlMVUqC" : {
+    "adc": {
+      "EIC9__U1uCn0UaREPwlM7h2gYJ4J0EW042qzpjlMVUqC": {
         "d": "EKQQI3VidGhzMSwYYgxMbXSlLriWFbnvE1WJcDqM8aF2",
         "type": "community/adc/extension/1.0",
         "bundle_digest": "ECCmcOBQWZc_Ck5q4BmDvlrvPabUTuXQkXYt_2TeAyNV",
         "overlays": {
+          "form": [
+            {
+              "d": "###formDigest###",
+              "capture_base": "EIC9__U1uCn0UaREPwlM7h2gYJ4J0EW042qzpjlMVUqC",
+              "type": "###formType###",
+              "language": "eng",
+              "subheading": {
+                "page-1": "subheading: Catalogue Writer"
+              },
+              "interaction": [
+                {
+                  "arguments": {
+                    "contributorName": {
+                      "type": "Text",
+                      "placeholder": "Family-Name, Given-Name"
+                    },
+                    "creatorName": {
+                      "type": "Text",
+                      "placeholder": "Family-Name, Given-Name"
+                    },
+                    "date": {
+                      "type": "DateTime",
+                      "placeholder": "YYYY-MM-DD"
+                    },
+                    "format": {
+                      "type": "Text",
+                      "placeholder": "PDF, XML, application/pdf, text/xml, etc..."
+                    },
+                    "geoLocationBox": {
+                      "type": "Text",
+                      "placeholder": "(Lower-corner) (Upper-corner): \"41.090 -71.032 42.893 -68.211\""
+                    },
+                    "geoLocationPoint": {
+                      "type": "Text",
+                      "placeholder": "Latitude Longitude: \"31.233 -67.302\""
+                    },
+                    "identifier": {
+                      "type": "Text",
+                      "placeholder": "10.1234/foo"
+                    },
+                    "language": {
+                      "type": "Text",
+                      "placeholder": "en-CA, en, etc..."
+                    },
+                    "publicationYear": {
+                      "type": "DateTime",
+                      "placeholder": "YYYY"
+                    },
+                    "relatedMetadataScheme": {
+                      "type": "Text",
+                      "placeholder": "Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)"
+                    },
+                    "rightsURI": {
+                      "type": "Text",
+                      "placeholder": "https://an.example.com/rightsURI"
+                    },
+                    "schemeType": {
+                      "type": "Text",
+                      "placeholder": "Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)"
+                    },
+                    "schemeURI": {
+                      "type": "Text",
+                      "placeholder": "https://an.example.com/schemeURI"
+                    },
+                    "size": {
+                      "type": "Text",
+                      "placeholder": "\"15 pages\", or \"6 MB\""
+                    }
+                  }
+                }
+              ],
+              "title": "Catalogue Writer"
+            },
+            {
+              "d": "###formDigest###",
+              "capture_base": "EIC9__U1uCn0UaREPwlM7h2gYJ4J0EW042qzpjlMVUqC",
+              "type": "###formType###",
+              "language": "fra",
+              "subheading": {
+                "page-1": "subheading: Catalogue Writer"
+              },
+              "interaction": [
+                {
+                  "arguments": {
+                    "contributorName": {
+                      "type": "Text",
+                      "placeholder": "French_Family-Name, Given-Name"
+                    },
+                    "creatorName": {
+                      "type": "Text",
+                      "placeholder": "French_Family-Name, Given-Name"
+                    },
+                    "date": {
+                      "type": "DateTime",
+                      "placeholder": "YYYY-MM-DD"
+                    },
+                    "format": {
+                      "type": "Text",
+                      "placeholder": "French_PDF, XML, application/pdf, text/xml, etc..."
+                    },
+                    "geoLocationBox": {
+                      "type": "Text",
+                      "placeholder": "French_(Lower-corner) (Upper-corner): \"41.090 -71.032 42.893 -68.211\""
+                    },
+                    "geoLocationPoint": {
+                      "type": "Text",
+                      "placeholder": "French_Latitude Longitude: \"31.233 -67.302\""
+                    },
+                    "identifier": {
+                      "type": "Text",
+                      "placeholder": "French_10.1234/foo"
+                    },
+                    "language": {
+                      "type": "Text",
+                      "placeholder": "French_en-CA, en, etc..."
+                    },
+                    "publicationYear": {
+                      "type": "DateTime",
+                      "placeholder": "YYYY"
+                    },
+                    "relatedMetadataScheme": {
+                      "type": "Text",
+                      "placeholder": "French_Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)"
+                    },
+                    "rightsURI": {
+                      "type": "Text",
+                      "placeholder": "French_https://an.example.com/rightsURI"
+                    },
+                    "schemeType": {
+                      "type": "Text",
+                      "placeholder": "French_Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)"
+                    },
+                    "schemeURI": {
+                      "type": "Text",
+                      "placeholder": "French_https://an.example.com/schemeURI"
+                    },
+                    "size": {
+                      "type": "Text",
+                      "placeholder": "French_\"15 pages\", or \"6 MB\""
+                    }
+                  }
+                }
+              ],
+              "title": "Catalogue Writer"
+            }
+          ],
           "ordering": {
             "d": "EJzB4B_sFyi9DswKkyVI4mLLU1Jyw3XSBIUYhdQupFGD",
-            "type": "community/overlays/adc/ordering/1.0",
             "capture_base": "EIC9__U1uCn0UaREPwlM7h2gYJ4J0EW042qzpjlMVUqC",
+            "type": "community/overlays/adc/ordering/1.0",
             "attribute_ordering": [
               "identifier",
               "identifierType",
@@ -1449,157 +1595,7 @@
             "entry_code_ordering": {
               "identifierType": ["ARK", "DOI", "Handle", "PURL", "URL", "URN"]
             }
-          },
-          "form": [
-            {
-              "d": "###presentationDigest###",
-              "type": "###presentationType###",
-              "language": [
-                "eng",
-                "fra"
-              ],
-              "pages": [
-                {
-                  "named_section": "page-1"
-                }
-              ],
-              "page_order": [
-                "page-1"
-              ],
-              "page_labels": {
-                "eng": {
-                  "page-1": "Page 1: Catalogue Writer"
-                },
-                "fra": {
-                  "page-1": "Page 1: Catalogue Writer"
-                }
-              },
-              "sidebar_label": {
-                "eng": {
-                  "page-1": "sidebar: Catalogue Writer"
-                },
-                "fra": {
-                  "page-1": "sidebar: Catalogue Writer"
-                }
-              },
-              "subheading": {
-                "eng": {
-                  "page-1": "subheading: Catalogue Writer"
-                },
-                "fra": {
-                  "page-1": "subheading: Catalogue Writer"
-                }
-              },
-              "interaction": [
-                {
-                  "arguments": {
-                    "contributorName": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "Family-Name, Given-Name",
-                        "fra": "Family-Name, Given-Name"
-                      }
-                    },
-                    "creatorName": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "Family-Name, Given-Name",
-                        "fra": "Family-Name, Given-Name"
-                      }
-                    },
-                    "date": {
-                      "type": "DateTime",
-                      "placeholder": {
-                        "eng": "YYYY-MM-DD",
-                        "fra": "YYYY-MM-DD"
-                      }
-                    },
-                    "format": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "PDF, XML, application/pdf, text/xml, etc...",
-                        "fra": "PDF, XML, application/pdf, text/xml, etc..."
-                      }
-                    },
-                    "geoLocationBox": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "(Lower-corner) (Upper-corner): \"41.090 -71.032 42.893 -68.211\"",
-                        "fra": "(Lower-corner) (Upper-corner): \"41.090 -71.032 42.893 -68.211\""
-                      }
-                    },
-                    "geoLocationPoint": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "Latitude Longitude: \"31.233 -67.302\"",
-                        "fra": "Latitude Longitude: \"31.233 -67.302\""
-                      }
-                    },
-                    "identifier": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "10.1234/foo",
-                        "fra": "10.1234/foo"
-                      }
-                    },
-                    "language": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "en-CA, en, etc...",
-                        "fra": "en-CA, en, etc..."
-                      }
-                    },
-                    "publicationYear": {
-                      "type": "DateTime",
-                      "placeholder": {
-                        "eng": "YYYY",
-                        "fra": "YYYY"
-                      }
-                    },
-                    "relatedMetadataScheme": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)",
-                        "fra": "Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)"
-                      }
-                    },
-                    "rightsURI": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "https://an.example.com/rightsURI",
-                        "fra": "https://an.example.com/rightsURI"
-                      }
-                    },
-                    "schemeType": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)",
-                        "fra": "Use only with relation pair: (`HasMetadata` / `IsMetadataFor`)"
-                      }
-                    },
-                    "schemeURI": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "https://an.example.com/schemeURI",
-                        "fra": "https://an.example.com/schemeURI"
-                      }
-                    },
-                    "size": {
-                      "type": "textarea",
-                      "placeholder": {
-                        "eng": "\"15 pages\", or \"6 MB\"",
-                        "fra": "\"15 pages\", or \"6 MB\""
-                      }
-                    }
-                  }
-                }
-              ],
-              "title": {
-                "eng": "Catalogue Writer",
-                "fra": "Catalogue Writer"
-              }
-            }
-          ]
+          }
         }
       }
     }

--- a/src/components/Stateful/DynamicForm.jsx
+++ b/src/components/Stateful/DynamicForm.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import { isEqual } from "lodash";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
-// import Typography from "@mui/material/Typography";
+import Typography from "@mui/material/Typography";
 import FormInputSingle from "./DynamicFormComponents/FormInputSingle";
 import FormInputMultiple from "./DynamicFormComponents/FormInputMultiple";
 import FormInputGroup from "./DynamicFormComponents/FormInputGroup";
@@ -14,7 +14,6 @@ import { v4 as uuidv4 } from "uuid";
 import SaveIcon from "@mui/icons-material/Save";
 import SendIcon from "@mui/icons-material/Send";
 import { useTranslation } from "../../utils/OpenAIRE/TranslationContext";
-
 //
 const checkMultipleEntriesFilled = (fields, state) => {
   for (const field of fields) {
@@ -278,10 +277,9 @@ function DynamicForm({
           name={name}
           path={path}
           depth={depth}
-          value={value}
           renderInput={renderInput}
+          required={required}
           readOnly={readOnly}
-          isEditMode={isEditMode}
         />
       );
     }
@@ -370,6 +368,16 @@ function DynamicForm({
           {t("dynamicform.complete")}
         </Button>
       </Box>
+
+      {!readOnly && (
+        <Typography
+          sx={{ mb: "20px", fontSize: "13px" }}
+        >
+          {t("All fields with ( ")}
+          <span style={{ color: "red"}}>*</span>
+          {t(" ) are Mandatory")}
+        </Typography>
+      )}
 
       {/* GENERATED FORM (RECURSICE INPUT RENDERING + SUBMIT BUTTON) */}
       <form onSubmit={handleSubmit}>

--- a/src/components/Stateful/DynamicFormComponents/FormInputGroup.jsx
+++ b/src/components/Stateful/DynamicFormComponents/FormInputGroup.jsx
@@ -14,7 +14,8 @@ const FormInputGroup = ({
   path, 
   depth = 0, 
   renderInput, 
-  required
+  required,
+  readOnly
 }) => {
   return (
     <Box>
@@ -22,7 +23,9 @@ const FormInputGroup = ({
         {label || name}
         {/* Show asterisk only if group itself is required, otherwise nothing */}
         {required && (
-          <span style={{ color: "red", marginLeft: 4 }}>*</span>
+          !readOnly && (
+            <span style={{ color: "red", marginLeft: 4 }}>*</span>
+          )
         )}
       </Typography>
       {children.map((child) =>

--- a/src/components/Stateful/DynamicFormComponents/FormInputMultiple.jsx
+++ b/src/components/Stateful/DynamicFormComponents/FormInputMultiple.jsx
@@ -48,7 +48,9 @@ const FormInputMultiple = ({
       <Typography variant={depth === 0 ? "h6" : "h8"}>
         {label || name}
         {required && (
-          <span style={{ color: "red", marginLeft: 4 }}>*</span>
+          !readOnly && (
+            <span style={{ color: "red", marginLeft: 4 }}>*</span>
+          )
         )}
       </Typography>
 

--- a/src/components/Stateful/DynamicFormComponents/FormInputSingle.jsx
+++ b/src/components/Stateful/DynamicFormComponents/FormInputSingle.jsx
@@ -43,7 +43,9 @@ const FormInputSingle = ({
       >
         {label || name}
         {required && (
-          <span style={{ color: "red", marginLeft: 4 }}>*</span>
+          !readOnly && (
+            <span style={{ color: "red", marginLeft: 4 }}>*</span>
+          )
         )}
       </Typography>
 

--- a/src/components/Stateless/PageHeaders.jsx
+++ b/src/components/Stateless/PageHeaders.jsx
@@ -7,6 +7,7 @@ import {
   Button
 } from "@mui/material";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import { useNavigate } from "react-router-dom";
 
 function PageHeaders({
     page_heading,
@@ -17,6 +18,7 @@ function PageHeaders({
     const { t } = useTranslation();  // use translation function
     console.log("help_button_redirect:", help_button_redirect, "type:", typeof help_button_redirect);
 
+    const navigate = useNavigate();
 
     return (
         <div className="Header">
@@ -32,11 +34,10 @@ function PageHeaders({
             >
             <Stack direction={"row"} alignItems={"center"}>
                 <Box
-                    component="a"
-                    href="https://agrifooddatacanada.ca/"
-                    target="_blank"
-                    rel="noreferrer"
+                    onClick={() => navigate('/')}
+
                     sx={{
+                        cursor: 'pointer',
                         marginLeft: "0px !important",
                         "& img": {
                         maxWidth: "100px",

--- a/src/hooks/useDynamicFormState.js
+++ b/src/hooks/useDynamicFormState.js
@@ -104,7 +104,8 @@ function useDynamicFormState(jsonData, language = "eng", initialData = null) {
         // EXTRACT FORMAT PATTERNS
         const { fields: extractedFields, formatPatterns } = extractAttributes(
             jsonData,
-            "capture_base"
+            "capture_base",
+            language
         );
 
         if (!Array.isArray(extractedFields)) {

--- a/src/pages/FormHelpPage.jsx
+++ b/src/pages/FormHelpPage.jsx
@@ -20,7 +20,7 @@ function ViewHelpPage() {
             />
 
             <Box sx={{ maxWidth: 1000, margin: "auto", padding: 5 }}>
-                This page is under development...
+                {t("formhelppage.under_development")}
             </Box>
             <Footer
                 powered_by={t("powered_by")}

--- a/src/pages/FormPage.jsx
+++ b/src/pages/FormPage.jsx
@@ -33,7 +33,7 @@ function FormPage() {
     <div className="FormPage">
       <PageHeaders
         page_heading={ uploadedJson ? t("formpage.edit_header") : t("formpage.write_header") }
-        tooltip_description="You can write your catalogue record on this page."
+        tooltip_description={ uploadedJson ? t("formpage.edit_tooltip") : t("formpage.write_tooltip") }
         help_button_redirect={() => navigate("/form-help", { state: { uploadedJson: uploadedJson } })}
       />
 

--- a/src/pages/ViewHelpPage.jsx
+++ b/src/pages/ViewHelpPage.jsx
@@ -19,7 +19,7 @@ function ViewHelpPage() {
             />
 
             <Box sx={{ maxWidth: 1000, margin: "auto", padding: 5 }}>
-                This page is under development...
+                {t("viewhelppage.under_development")}
             </Box>
             <Footer
                 powered_by={t("powered_by")}

--- a/src/pages/ViewPage.jsx
+++ b/src/pages/ViewPage.jsx
@@ -53,7 +53,7 @@ function ViewPage() {
     <div className="ViewPage">
       <PageHeaders
         page_heading={ isModified ? t("viewpage.review"): t("viewpage.view") }
-        tooltip_description="You can view your catalogue record in a human-readable form on this page."
+        tooltip_description={ isModified ? t("viewpage.review_tooltip") : t("viewpage.view_tooltip") }
         help_button_redirect={() => navigate("/view-help", { state: { isModified: isModified } })}
       />
 

--- a/src/utils/OpenAIRE/translations/eng.json
+++ b/src/utils/OpenAIRE/translations/eng.json
@@ -1,77 +1,83 @@
 {
-    "homepage": {
-        "semantic_engine": "Semantic Engine",
-        "catalogue": "Catalogue",
-        "content_heading": "Catalogue your work",
-        "content": "Make it easier for others to track your work and cite what you make",
-        "quick_start_heading": "Quick-Start:",
-        "step_1": "1. ",
-        "watch_tutorial_video": "Watch our tutorial video on creating a catalogue.",
-        "or": " Or ",
-        "read_the_tutorial": "read the tutorial ",
-        "instead": "instead.",
-        "step_2": "2. Write your catalogue and generate a .json.",
-        "step_3": "3. Use your catalogue here to view, and generate a JSON-LD for data input aligned with Open-AIRE metadata standards.",
-        "step_4": "4. Store your catalogue files with your data, put them in a repository, or collaborate by sharing them with others.",
-        "accordion_question_1": "1. What is a Catalogue?",
-        "accordion_summary_1": "1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
-        "accordion_question_2": "2. What is a Catalogue?",
-        "accordion_summary_2": "2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
-        "accordion_question_3": "3. What is a Catalogue?",
-        "accordion_summary_3": "3. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
-        "quick_links": "Quick Links",
-        "write": "Write a Catalogue Record",
-        "upload_file": "Upload a previous Catalogue Record or drag and drop one (.json file)",
-        "file_uploaded": "File uploaded: ",
-        "view": "View Catalogue Record",
-        "edit": "Edit Catalogue Record"
-    },
-    "formpage": {
-        "edit_header": "Edit Catalogue Record",
-        "write_header": "Write Catalogue Record",
-        "loading": "Loading..."
-    },
-    "dynamicform": {
-        "mandatory": "Mandatory",
-        "recommended": "Recommended",
-        "complete": "Complete",
-        "save_changes": "Save Changes",
-        "review": "Review"
-    },
-    "viewpage": {
-        "loading": "Loading schema...",
-        "no_catalogue": "No catalogue loaded. Please upload a file first and only then can you view it.",
-        "review": "Review Catalogue Record",
-        "view": "View Catalogue Record",
-        "edit": "Edit",
-        "download": "Download (.json)"
-    },
-    "forminputmultiple": {
-        "actions": "Actions",
-        "edit": "Edit",
-        "delete": "Delete",
-        "add": "Add"
-    },
-    "forminputsingle": {
-        "select": "Select",
-        "none": "None",
-        "enter": "Enter"
-    },
-    "popupdialog": {
-        "add": "Add",
-        "cancel": "Cancel",
-        "save": "Save"
-    },
-    "viewhelppage": {
-        "review": "Help with Review Catalogue Page",
-        "view": "Help with View Catalogue Page"
-    },
-    "formhelppage": {
-        "edit": "Help with Edit Catalogue Page",
-        "write": "Help with Write Catalogue Page"
-    },
-    "no_data": "No data exist for",
-    "powered_by": "Powered by",
-    "supported_by": "Supported by",
-    "page_help": "Help with this Page"
+  "homepage": {
+    "semantic_engine": "Semantic Engine",
+    "catalogue": "Catalogue",
+    "content_heading": "Catalogue your work",
+    "content": "Make it easier for others to track your work and cite what you make",
+    "quick_start_heading": "Quick-Start:",
+    "step_1": "1. ",
+    "watch_tutorial_video": "Watch our tutorial video on creating a catalogue.",
+    "or": " Or ",
+    "read_the_tutorial": "read the tutorial ",
+    "instead": "instead.",
+    "step_2": "2. Write your catalogue and generate a .json.",
+    "step_3": "3. Use your catalogue here to view, and generate a JSON-LD for data input aligned with Open-AIRE metadata standards.",
+    "step_4": "4. Store your catalogue files with your data, put them in a repository, or collaborate by sharing them with others.",
+    "accordion_question_1": "1. What is a Catalogue?",
+    "accordion_summary_1": "1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
+    "accordion_question_2": "2. What is a Catalogue?",
+    "accordion_summary_2": "2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
+    "accordion_question_3": "3. What is a Catalogue?",
+    "accordion_summary_3": "3. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
+    "quick_links": "Quick Links",
+    "write": "Write a Catalogue Record",
+    "upload_file": "Upload a previous Catalogue Record or drag and drop one (.json file)",
+    "file_uploaded": "File uploaded: ",
+    "view": "View Catalogue Record",
+    "edit": "Edit Catalogue Record"
+  },
+  "formpage": {
+    "edit_header": "Edit Catalogue Record",
+    "write_header": "Write Catalogue Record",
+    "loading": "Loading...",
+    "edit_tooltip": "You can edit your catalogue record on this page.",
+    "write_tooltip": "You can write your catalogue record on this page."
+  },
+  "dynamicform": {
+    "mandatory": "Mandatory",
+    "recommended": "Recommended",
+    "complete": "Complete",
+    "save_changes": "Save Changes",
+    "review": "Review"
+  },
+  "viewpage": {
+    "loading": "Loading schema...",
+    "no_catalogue": "No catalogue loaded. Please upload a file first and only then can you view it.",
+    "review": "Review Catalogue Record",
+    "view": "View Catalogue Record",
+    "edit": "Edit",
+    "download": "Download (.json)",
+    "review_tooltip": "You can review your catalogue record in a human-readable form on this page.",
+    "view_tooltip": "You can view your catalogue record in a human-readable form on this page."
+  },
+  "forminputmultiple": {
+    "actions": "Actions",
+    "edit": "Edit",
+    "delete": "Delete",
+    "add": "Add"
+  },
+  "forminputsingle": {
+    "select": "Select",
+    "none": "None",
+    "enter": "Enter"
+  },
+  "popupdialog": {
+    "add": "Add",
+    "cancel": "Cancel",
+    "save": "Save"
+  },
+  "viewhelppage": {
+    "review": "Help with Review Catalogue Page",
+    "view": "Help with View Catalogue Page",
+    "under_development": "This page is under development..."
+  },
+  "formhelppage": {
+    "edit": "Help with Edit Catalogue Page",
+    "write": "Help with Write Catalogue Page",
+    "under_development": "This page is under development..."
+  },
+  "no_data": "No data exist for",
+  "powered_by": "Powered by",
+  "supported_by": "Supported by",
+  "page_help": "Help with this Page"
 }

--- a/src/utils/OpenAIRE/translations/fra.json
+++ b/src/utils/OpenAIRE/translations/fra.json
@@ -1,77 +1,83 @@
 {
-    "homepage": {
-        "semantic_engine": "Semantic Engine",
-        "catalogue": "Catalogue",
-        "content_heading": "Cataloguez votre travail",
-        "content": "Facilitez la tâche aux autres pour suivre votre travail et citer ce que vous créez",
-        "quick_start_heading": "Démarrage rapide:",
-        "step_1": "1. ",
-        "watch_tutorial_video": "Regardez notre vidéo tutorielle sur la création d’un Catalogue.",
-        "or": " Ou ",
-        "read_the_tutorial": "lisez le tutoriel ",
-        "instead": "à la place.",
-        "step_2": "2. Rédigez votre Catalogue et générez un fichier .json.",
-        "step_3": "3. Utilisez votre Catalogue ici pour visualiser et générer un JSON-LD destiné à l’entrée des données conforme aux standards de métadonnées Open-AIRE.",
-        "step_4": "4. Stockez vos fichiers de Catalogue avec vos données, placez-les dans un dépôt ou collaborez en les partageant avec d’autres.",
-        "accordion_question_1": "1. Qu’est-ce qu’un Catalogue ?",
-        "accordion_summary_1": "1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
-        "accordion_question_2": "2. Qu’est-ce qu’un Catalogue ?",
-        "accordion_summary_2": "2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
-        "accordion_question_3": "3. Qu’est-ce qu’un Catalogue ?",
-        "accordion_summary_3": "3. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
-        "quick_links": "Liens rapides",
-        "write": "Rédigez un enregistrement de Catalogue",
-        "upload_file": "Téléchargez un enregistrement de Catalogue précédent ou glissez-déposez un fichier (.json)",
-        "file_uploaded": "Fichier téléchargé : ",
-        "view": "Voir l’enregistrement du Catalogue",
-        "edit": "Modifier l’enregistrement du Catalogue"
-    },
-    "formpage": {
-        "edit_header": "Modifier l’enregistrement du Catalogue",
-        "write_header": "Rédiger un enregistrement du Catalogue",
-        "loading": "Loading..."
-    },
-    "dynamicform": {
-        "mandatory": "Obligatoire",
-        "recommended": "Recommandé",
-        "complete": "Complété",
-        "save_changes": "Enregistrer les modifications",
-        "review": "Réviser"
-    },
-    "viewpage": {
-        "loading": "Chargement du schéma...",
-        "no_catalogue": "Aucun Catalogue chargé. Veuillez d'abord télécharger un fichier pour pouvoir le visualiser ensuite.",
-        "review": "Réviser l’enregistrement du Catalogue",
-        "view": "Voir l’enregistrement du Catalogue",
-        "edit": "Modifier",
-        "download": "Télécharger (.json)"
-    },
-    "forminputmultiple": {
-        "actions": "Actions",
-        "edit": "Modifier",
-        "delete": "Supprimer",
-        "add": "Ajouter"
-    },
-    "forminputsingle": {
-        "select": "Sélectionner",
-        "none": "Aucun",
-        "enter": "Entrer"
-    },
-    "popupdialog": {
-        "add": "Ajouter",
-        "cancel": "Annuler",
-        "save": "Enregistrer"
-    },
-    "viewhelppage": {
-        "review": "Aide pour la page du Catalogue des avis",
-        "view": "Aide pour la page du Catalogue des consultations"
-    },
-    "formhelppage": {
-        "edit": "Aide pour la page de modification du Catalogue",
-        "write": "Aide pour la page de rédaction du Catalogue"
-    },
-    "no_data": "Aucune donnée n’existe pour",
-    "powered_by": "Propulsé par",
-    "supported_by": "Soutenu par",
-    "page_help": "Aide pour cette page"
+  "homepage": {
+    "semantic_engine": "Semantic Engine",
+    "catalogue": "Catalogue",
+    "content_heading": "Cataloguez votre travail",
+    "content": "Facilitez la tâche aux autres pour suivre votre travail et citer ce que vous créez",
+    "quick_start_heading": "Démarrage rapide:",
+    "step_1": "1. ",
+    "watch_tutorial_video": "Regardez notre vidéo tutorielle sur la création d’un Catalogue.",
+    "or": " Ou ",
+    "read_the_tutorial": "lisez le tutoriel ",
+    "instead": "à la place.",
+    "step_2": "2. Rédigez votre Catalogue et générez un fichier .json.",
+    "step_3": "3. Utilisez votre Catalogue ici pour visualiser et générer un JSON-LD destiné à l’entrée des données conforme aux standards de métadonnées Open-AIRE.",
+    "step_4": "4. Stockez vos fichiers de Catalogue avec vos données, placez-les dans un dépôt ou collaborez en les partageant avec d’autres.",
+    "accordion_question_1": "1. Qu’est-ce qu’un Catalogue ?",
+    "accordion_summary_1": "1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
+    "accordion_question_2": "2. Qu’est-ce qu’un Catalogue ?",
+    "accordion_summary_2": "2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
+    "accordion_question_3": "3. Qu’est-ce qu’un Catalogue ?",
+    "accordion_summary_3": "3. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.",
+    "quick_links": "Liens rapides",
+    "write": "Rédigez un enregistrement de Catalogue",
+    "upload_file": "Téléchargez un enregistrement de Catalogue précédent ou glissez-déposez un fichier (.json)",
+    "file_uploaded": "Fichier téléchargé : ",
+    "view": "Voir l’enregistrement du Catalogue",
+    "edit": "Modifier l’enregistrement du Catalogue"
+  },
+  "formpage": {
+    "edit_header": "Modifier l’enregistrement du Catalogue",
+    "write_header": "Rédiger un enregistrement du Catalogue",
+    "loading": "Chargement...",
+    "edit_tooltip": "Vous pouvez modifier votre fiche de catalogue sur cette page.",
+    "write_tooltip": "Vous pouvez rédiger votre fiche de catalogue sur cette page."
+  },
+  "dynamicform": {
+    "mandatory": "Obligatoire",
+    "recommended": "Recommandé",
+    "complete": "Complété",
+    "save_changes": "Enregistrer les modifications",
+    "review": "Réviser"
+  },
+  "viewpage": {
+    "loading": "Chargement du schéma...",
+    "no_catalogue": "Aucun Catalogue chargé. Veuillez d'abord télécharger un fichier pour pouvoir le visualiser ensuite.",
+    "review": "Réviser l’enregistrement du Catalogue",
+    "view": "Voir l’enregistrement du Catalogue",
+    "edit": "Modifier",
+    "download": "Télécharger (.json)",
+    "review_tooltip": "Vous pouvez examiner votre fiche de catalogue sous une forme lisible par l’humain sur cette page.",
+    "view_tooltip": "Vous pouvez consulter votre fiche de catalogue sous une forme lisible par l’humain sur cette page."
+  },
+  "forminputmultiple": {
+    "actions": "Actions",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "add": "Ajouter"
+  },
+  "forminputsingle": {
+    "select": "Sélectionner",
+    "none": "Aucun",
+    "enter": "Entrer"
+  },
+  "popupdialog": {
+    "add": "Ajouter",
+    "cancel": "Annuler",
+    "save": "Enregistrer"
+  },
+  "viewhelppage": {
+    "review": "Aide pour la page du Catalogue des avis",
+    "view": "Aide pour la page du Catalogue des consultations",
+    "under_development": "Cette page est en cours de développement..."
+  },
+  "formhelppage": {
+    "edit": "Aide pour la page de modification du Catalogue",
+    "write": "Aide pour la page de rédaction du Catalogue",
+    "under_development": "Cette page est en cours de développement..."
+  },
+  "no_data": "Aucune donnée n’existe pour",
+  "powered_by": "Propulsé par",
+  "supported_by": "Soutenu par",
+  "page_help": "Aide pour cette page"
 }


### PR DESCRIPTION
Made changes to the structure of overlays in extensions and added logic to default to the 1st language available for `label`, and `entry` if and specific `language` not found.

Added a statement to mention the fields with red asterisks are mandatory.

Removed red asterisks from the input field labels in View and Review mode.

Changed the redirection of Semantic Engine logo on Page Headers from `agrifooddatacanada` website to Home Page of Catalogue Writer.