### PR TITLE
Resolved an issue with Select input fields

### DIFF
--- a/src/components/Stateful/DynamicFormComponents/FormInputSingle.jsx
+++ b/src/components/Stateful/DynamicFormComponents/FormInputSingle.jsx
@@ -60,6 +60,8 @@ const FormInputSingle = ({ valuePath, depth = 0 }) => {
     categories,
   } = field;
 
+  console.log("categories:", categories);
+
   const instanceCount = useSelector(selectInstanceCount(fieldPath)) || 0;
   const fieldValues = useSelector(selectFormValueByPrefix(fieldPath));
 
@@ -345,7 +347,7 @@ const FormInputSingle = ({ valuePath, depth = 0 }) => {
                   </MenuItem>
                 )}
                 {categories.map((option) => {
-                  const code = option.split(" ")[0];
+                  const code = option.split(" (")[0];
                   return (
                     <MenuItem key={code} value={code}>
                       {option}
@@ -385,7 +387,7 @@ const FormInputSingle = ({ valuePath, depth = 0 }) => {
               <FormControl fullWidth {...fieldErrorProps} sx={{ p: 1 }}>
                 <FormGroup>
                   {categories.map((option) => {
-                    const code = option.split(" ")[0];
+                    const code = option.split(" (")[0];
 
                     // Check if ANY instance has this code
                     const isChecked = existingValues.includes(code);

--- a/src/components/Stateful/DynamicFormComponents/FormInputSingle.jsx
+++ b/src/components/Stateful/DynamicFormComponents/FormInputSingle.jsx
@@ -60,8 +60,6 @@ const FormInputSingle = ({ valuePath, depth = 0 }) => {
     categories,
   } = field;
 
-  console.log("categories:", categories);
-
   const instanceCount = useSelector(selectInstanceCount(fieldPath)) || 0;
   const fieldValues = useSelector(selectFormValueByPrefix(fieldPath));
 
@@ -112,7 +110,6 @@ const FormInputSingle = ({ valuePath, depth = 0 }) => {
 
   const mode = useSelector(selectMode);
   const readOnly = mode === "view";
-  // console.log("mode:", mode, "| readOnly:", readOnly);
 
   const [touched, setTouched] = useState(false);
 


### PR DESCRIPTION
The values and keys for <Select> input fields were incorrectly fetched and stored by splitting based on " ". They will now be split based on " (" as a temporary fix until a fool-proof solution is thought of.