### PR TITLE
Changed logo redirect

### DIFF
--- a/src/components/Stateless/PageHeaders.jsx
+++ b/src/components/Stateless/PageHeaders.jsx
@@ -28,7 +28,7 @@ function PageHeaders({
         <Stack direction={"row"} alignItems={"center"}>
           <Box
             component="a"
-            href="/"
+            href="https://www.semanticengine.org/"
             sx={{
               cursor: "pointer",
               marginLeft: "0px !important",


### PR DESCRIPTION
Previously the Semantic Engine logo used to redirect to [Record Writer Home Page](https://www.records.semanticengine.org/), now it redirects to [Semantic Engine Home Page](https://www.semanticengine.org/)